### PR TITLE
Fixed uninitialized source directory variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ if(NOT is_windows_store)
   set_target_properties(bzip2_bin PROPERTIES OUTPUT_NAME bzip2)
 endif()
 
+set( bzip2_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR} )
 file(GLOB man1 ${bzip2_SOURCE_DIR}/*.1)
 
 


### PR DESCRIPTION
bzip2_SOURCE_DIR is not set prior to being used and the install command fails if *.1 files exist in the system root directory.